### PR TITLE
Actually use oily_png instead of chunky_png.

### DIFF
--- a/lib/monster_id/monster.rb
+++ b/lib/monster_id/monster.rb
@@ -1,4 +1,4 @@
-require 'chunky_png'
+require 'oily_png'
 require 'digest'
 require 'base64'
 


### PR DESCRIPTION
It seems you intended to use `oily_png` (it is referenced in the gem spec). But to actually use it, you have to require it instead of `chunky_png` (see the usage section in https://github.com/wvanbergen/oily_png).
