### PR TITLE
Fixing usage text and example image links

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -2,11 +2,9 @@ A Ruby port of [monsterid](http://www.splitbrain.org/projects/monsterid).
 
 ## Usage
 
-    MonsterID.new('your_seed').save('monster.png')
-
-    MonsterID.new('a_seed').to_data_uri
-
-    MonsterID.new('your_seed').to_s # raw png
+    MonsterId.generate('your_seed').save('monster.png')
+    MonsterId.generate('a_seed').to_data_uri
+    MonsterId.generate('your_seed').to_s # raw png
 
 ![lovely eyes](https://raw.github.com/dira/monsterid/master/examples/lovely_eyes.png) ![](https://raw.github.com/dira/monsterid/master/examples/angry.png) ![](https://raw.github.com/dira/monsterid/master/examples/pointy.png) ![;)](https://raw.github.com/dira/monsterid/master/examples/wink.png)
 

--- a/README.mkd
+++ b/README.mkd
@@ -8,7 +8,7 @@ A Ruby port of [monsterid](http://www.splitbrain.org/projects/monsterid).
 
     MonsterID.new('your_seed').to_s # raw png
 
-![lovely eyes](/dira/monsterid/raw/master/examples/lovely_eyes.png) ![](/dira/monsterid/raw/master/examples/angry.png) ![](/dira/monsterid/raw/master/examples/pointy.png) ![;)](/dira/monsterid/raw/master/examples/wink.png)
+![lovely eyes](https://raw.github.com/dira/monsterid/master/examples/lovely_eyes.png) ![](https://raw.github.com/dira/monsterid/master/examples/angry.png) ![](https://raw.github.com/dira/monsterid/master/examples/pointy.png) ![;)](https://raw.github.com/dira/monsterid/master/examples/wink.png)
 
 ### License
 


### PR DESCRIPTION
Looks like the example image like locations have changed with some github changes.  Also, the usage examples weren't quite correct.  Patched them up.  Thanks for the great little gem!
